### PR TITLE
fix: admin dashboard stale data, banner filtering, SSR crash, .length…

### DIFF
--- a/app/(page)/shop/page.jsx
+++ b/app/(page)/shop/page.jsx
@@ -28,7 +28,7 @@ export const metadata = {
 async function getCategories() {
   try {
     const res = await fetch(`${UrlBackend}/categories`, {
-      next: { revalidate: 3600 } // Cache for 1 hour
+      next: { revalidate: 60 }
     });
     if (!res.ok) return [];
     const json = await res.json();

--- a/app/LayoutWrapper.jsx
+++ b/app/LayoutWrapper.jsx
@@ -6,14 +6,19 @@ import DropshippingNavbar from "@/src/dropShipping/dropshippingNavbar/dropshippi
 import BlockedUserRoute from "@/src/utlis/BlockedUserRoute";
 import { useGetUser } from "@/src/utlis/useGetuser";
 import { usePathname } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { useDispatch } from "react-redux";
+import { hydrateCoupon } from "@/src/redux/cartSlice";
 
 
 export default function LayoutWrapper({ children, initialWebsiteInfo }) {
   const pathname = usePathname();
   const hideLayout = pathname.startsWith("/dashboard");
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(hydrateCoupon());
+  }, [dispatch]);
 
   const { user, loading } = useGetUser();
   const role = user?.role;

--- a/app/api/revalidate/route.js
+++ b/app/api/revalidate/route.js
@@ -1,0 +1,28 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const secret = body.secret || request.headers.get("x-revalidate-secret");
+
+    if (secret !== process.env.REVALIDATION_SECRET) {
+      return NextResponse.json({ error: "Invalid secret" }, { status: 401 });
+    }
+
+    const paths = body.paths || ["/", "/shop"];
+
+    for (const path of paths) {
+      revalidatePath(path, "layout");
+    }
+
+    return NextResponse.json({
+      revalidated: true,
+      paths,
+      now: Date.now(),
+    });
+  } catch (error) {
+    console.error("Revalidation error:", error);
+    return NextResponse.json({ error: "Revalidation failed" }, { status: 500 });
+  }
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,12 +1,12 @@
 import { UrlBackend } from "@/src/confic/urlExport";
 import HomeContent from "./HomeContent";
 
-export const revalidate = 300;
+export const revalidate = 60;
 
 async function getCategories() {
   try {
     const res = await fetch(`${UrlBackend}/categories`, {
-      next: { revalidate: 3600 }
+      next: { revalidate: 60 }
     });
     if (!res.ok) return [];
     const json = await res.json();
@@ -19,7 +19,7 @@ async function getCategories() {
 async function getSubCategories() {
   try {
     const res = await fetch(`${UrlBackend}/subcategories`, {
-      next: { revalidate: 3600 }
+      next: { revalidate: 60 }
     });
     if (!res.ok) return [];
     const json = await res.json();
@@ -32,7 +32,7 @@ async function getSubCategories() {
 async function getBanners() {
   try {
     const res = await fetch(`${UrlBackend}/homeBannerRoutes/get`, {
-      next: { revalidate: 3600 }
+      next: { revalidate: 60 }
     });
     if (!res.ok) return [];
     const json = await res.json();

--- a/src/compronent/header/header.jsx
+++ b/src/compronent/header/header.jsx
@@ -720,7 +720,7 @@ const Header = ({ initialData }) => {
       </header>
 
       <BottomNav
-        cartCount={cartItems.length || 0}
+        cartCount={cartItems?.length || 0}
         menuCategories={menuCategories}
       />
     </>

--- a/src/confic/socket.jsx
+++ b/src/confic/socket.jsx
@@ -1,5 +1,10 @@
-import { io } from "socket.io-client";
-const socket = io("https://easyshoppingmallbd.com", {
-  transports: ["websocket"], 
-});
+let socket;
+
+if (typeof window !== "undefined") {
+  const { io } = require("socket.io-client");
+  socket = io("https://easyshoppingmallbd.com", {
+    transports: ["websocket", "polling"],
+  });
+}
+
 export default socket;

--- a/src/dashboard/Banners/homeSlider.jsx
+++ b/src/dashboard/Banners/homeSlider.jsx
@@ -14,7 +14,8 @@ import toast from "react-hot-toast";
 const HomeSliderPage = () => {
   const { canModify } = useDashboardPermission();
 
-  const { homebanner, loading, error, refetch } = useGetHomeBanner();
+  const [sliderFilter, setSliderFilter] = useState("USER");
+  const { homebanner, loading, error, refetch } = useGetHomeBanner(sliderFilter);
   const [sliders, setSliders] = useState([]);
 
   useEffect(() => {
@@ -35,7 +36,7 @@ const HomeSliderPage = () => {
     Description: "",
     images: "",
     linkUrl: "",
-    sliderFor: "USER",
+    sliderFor: sliderFilter,
   });
 
   const fileInputRef = useRef(null);
@@ -78,7 +79,7 @@ const HomeSliderPage = () => {
         Description: "",
         images: "",
         linkUrl: "",
-        sliderFor: "USER",
+        sliderFor: sliderFilter,
       });
 
       setIsAddDialogOpen(false);
@@ -132,7 +133,7 @@ const HomeSliderPage = () => {
         Description: "",
         images: "",
         linkUrl: "",
-        sliderFor: "USER",
+        sliderFor: sliderFilter,
       });
 
       if (typeof refetch === "function") refetch();
@@ -492,7 +493,7 @@ const HomeSliderPage = () => {
                       className="w-full px-4 py-3 bg-gray-800/50 border border-gray-700 rounded-xl text-slate-300 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     />
                   </div>
-                  <div>
+                   <div>
                     <label className="block text-gray-300 text-sm font-medium mb-2">
                       Slider For
                     </label>
@@ -506,6 +507,9 @@ const HomeSliderPage = () => {
                       <option value="USER">🛒 Retail Users</option>
                       <option value="DROPSHIPPING">📦 Dropshippers</option>
                     </select>
+                    <p className="text-gray-500 text-xs mt-1">
+                      Creating for: <span className={formData.sliderFor === "DROPSHIPPING" ? "text-purple-400" : "text-blue-400"}>{formData.sliderFor === "DROPSHIPPING" ? "Dropshippers" : "Retail Users"}</span>
+                    </p>
                   </div>
                 </div>
 
@@ -541,6 +545,36 @@ const HomeSliderPage = () => {
             <h3 className="text-2xl font-bold text-slate-300 mb-6">
               Manage Sliders
             </h3>
+
+            {/* Tab Toggle: USER vs DROPSHIPPING */}
+            <div className="flex gap-2 mb-6">
+              <button
+                onClick={() => {
+                  setSliderFilter("USER");
+                  setFormData((prev) => ({ ...prev, sliderFor: "USER" }));
+                }}
+                className={`px-5 py-2.5 rounded-xl font-semibold text-sm transition-all duration-200 ${
+                  sliderFilter === "USER"
+                    ? "bg-blue-600 text-white shadow-lg shadow-blue-500/25"
+                    : "bg-gray-800/50 text-gray-400 hover:bg-gray-700/50 hover:text-gray-300"
+                }`}
+              >
+                🛒 Retail Users
+              </button>
+              <button
+                onClick={() => {
+                  setSliderFilter("DROPSHIPPING");
+                  setFormData((prev) => ({ ...prev, sliderFor: "DROPSHIPPING" }));
+                }}
+                className={`px-5 py-2.5 rounded-xl font-semibold text-sm transition-all duration-200 ${
+                  sliderFilter === "DROPSHIPPING"
+                    ? "bg-purple-600 text-white shadow-lg shadow-purple-500/25"
+                    : "bg-gray-800/50 text-gray-400 hover:bg-gray-700/50 hover:text-gray-300"
+                }`}
+              >
+                📦 Dropshippers
+              </button>
+            </div>
 
             {sliders?.length === 0 ? (
               <div className="text-center py-12">

--- a/src/dashboard/coupons/manageCoupons.jsx
+++ b/src/dashboard/coupons/manageCoupons.jsx
@@ -89,8 +89,8 @@ const ManageCoupons = () => {
     try {
       const [couponRes, catRes, subRes] = await Promise.all([
         getAllCoupons(),
-        CategoryAllGet(dispatch),
-        SubCategoryAllGet(dispatch),
+        CategoryAllGet(dispatch, "all"),
+        SubCategoryAllGet(dispatch, null, "all"),
       ]);
 
       if (couponRes.success) setCoupons(couponRes.data);

--- a/src/dashboard/order/completedOrder.jsx
+++ b/src/dashboard/order/completedOrder.jsx
@@ -411,7 +411,7 @@ const CompletedOrdersPage = () => {
                     {/* Order Items */}
                     <div className="mb-4">
                       <h5 className="text-slate-300 font-medium mb-2">
-                        Items ({order?.products.length})
+                        Items ({order?.products?.length ?? 0})
                       </h5>
                       <div className="space-y-1">
                         {order?.products.slice(0, 2).map((item, index) => (
@@ -427,9 +427,9 @@ const CompletedOrdersPage = () => {
                             </span>
                           </div>
                         ))}
-                        {order?.products.length > 2 && (
+                        {order?.products?.length > 2 && (
                           <p className="text-gray-500 text-xs">
-                            +{order?.products.length - 2} more items
+                            +{order?.products?.length - 2} more items
                           </p>
                         )}
                       </div>

--- a/src/dashboard/order/orderList.jsx
+++ b/src/dashboard/order/orderList.jsx
@@ -704,8 +704,8 @@ const OrderManagement = () => {
                             </div>
                             <div className="flex items-center gap-2">
                               <Package className="h-4 w-4" />
-                              {order?.products.length} item
-                              {order?.products.length > 1 ? "s" : ""}
+                              {order?.products?.length} item
+                              {order?.products?.length > 1 ? "s" : ""}
                             </div>
                           </div>
                         </div>
@@ -933,7 +933,7 @@ const OrderManagement = () => {
                         <div className="flex justify-between">
                           <span className="text-gray-400">Total Items:</span>
                           <span className="font-medium text-slate-300">
-                            {selectedOrder?.products.length}
+                            {selectedOrder?.products?.length}
                           </span>
                         </div>
 

--- a/src/dashboard/order/pendingOrder.jsx
+++ b/src/dashboard/order/pendingOrder.jsx
@@ -364,7 +364,7 @@ const PendingOrdersPage = () => {
                   {/* Order Items */}
                   <div className="mb-4">
                     <h5 className="text-slate-300 font-medium mb-2">
-                      Items ({order?.products.length})
+                      Items ({order?.products?.length})
                     </h5>
                     <div className="space-y-1">
                       {order?.products.slice(0, 2).map((item, index) => (
@@ -378,9 +378,9 @@ const PendingOrdersPage = () => {
                           <span className="text-gray-400">৳{item?.price}</span>
                         </div>
                       ))}
-                      {order?.products.length > 2 && (
+                      {order?.products?.length > 2 && (
                         <p className="text-gray-500 text-xs">
-                          +{order?.products.length - 2} more items
+                          +{order?.products?.length - 2} more items
                         </p>
                       )}
                     </div>
@@ -388,7 +388,7 @@ const PendingOrdersPage = () => {
                   {/* Order Items */}
                   <div className="mb-4">
                     <h5 className="text-slate-300 font-medium mb-2">
-                      Items ({order?.products.length})
+                      Items ({order?.products?.length})
                     </h5>
                     <div className="space-y-1">
                       {order?.products.slice(0, 2).map((item, index) => (
@@ -405,9 +405,9 @@ const PendingOrdersPage = () => {
                           </span>
                         </div>
                       ))}
-                      {order?.products.length > 2 && (
+                      {order?.products?.length > 2 && (
                         <p className="text-gray-500 text-xs">
-                          +{order?.products.length - 2} more items
+                          +{order?.products?.length - 2} more items
                         </p>
                       )}
                     </div>

--- a/src/dashboard/order/shippedOrder.jsx
+++ b/src/dashboard/order/shippedOrder.jsx
@@ -424,7 +424,7 @@ const ShippedOrdersPage = () => {
                 {/* Order Items */}
                 <div className="mb-4">
                   <h5 className="text-slate-300 font-medium mb-2">
-                    Items ({order?.products.length})
+                    Items ({order?.products?.length ?? 0})
                   </h5>
                   <div className="space-y-1">
                     {order?.products.slice(0, 2).map((item, index) => (
@@ -435,9 +435,9 @@ const ShippedOrdersPage = () => {
                         <span className="text-gray-400">৳{item?.price}</span>
                       </div>
                     ))}
-                    {order?.products.length > 2 && (
+                    {order?.products?.length > 2 && (
                       <p className="text-gray-500 text-xs">
-                        +{order?.products.length - 2} more items
+                        +{order?.products?.length - 2} more items
                       </p>
                     )}
                   </div>

--- a/src/dashboard/product/categories/addCategories.jsx
+++ b/src/dashboard/product/categories/addCategories.jsx
@@ -64,7 +64,7 @@ const AddCategoriesComponent = () => {
   const [categories, setCategories] = useState([]);
 
   useEffect(() => {
-    CategoryAllGet(dispatch);
+    CategoryAllGet(dispatch, "all");
   }, []);
 
   useEffect(() => {

--- a/src/dashboard/product/categories/subCategory.jsx
+++ b/src/dashboard/product/categories/subCategory.jsx
@@ -7,6 +7,7 @@ import {
   SubCategoryDelete,
   SubCategoryUploade,
 } from "@/src/hook/useSubcategory";
+import { CategoryAllGet } from "@/src/hook/usecategory";
 import { cn } from "@/src/utlis/utils";
 import {
   BarChart3,
@@ -79,7 +80,8 @@ const AddSubcategoriesComponent = () => {
   }, [allCategorydata]);
 
   useEffect(() => {
-    SubCategoryAllGet(dispatch);
+    SubCategoryAllGet(dispatch, null, "all");
+    CategoryAllGet(dispatch, "all");
   }, []);
 
   // Load categories

--- a/src/dropShipping/dropshippingSearch/DropshippingSearch.jsx
+++ b/src/dropShipping/dropshippingSearch/DropshippingSearch.jsx
@@ -665,7 +665,7 @@ const DropshippingSearchContent = () => {
                     {section.label}
                   </h2>
                   <span className="text-slate-400 text-xs sm:text-sm font-medium">
-                    ({section.products.length})
+                    ({section?.products?.length ?? 0})
                   </span>
                 </div>
 

--- a/src/hook/useHomeBanner.jsx
+++ b/src/hook/useHomeBanner.jsx
@@ -17,9 +17,12 @@ export const HomeBannerCreate = async (formData, ) => {
 };
 
 // HomeBanner ALL GET
-export const HomeBannerAllGet = async () => {
+export const HomeBannerAllGet = async (sliderFor) => {
   try {
-    const response = await apiClient.get(`/homeBannerRoutes/get`,  {
+    const url = sliderFor 
+      ? `/homeBannerRoutes/get?sliderFor=${sliderFor}` 
+      : `/homeBannerRoutes/get`;
+    const response = await apiClient.get(url, {
       withCredentials: true,
     });
     return response.data; 

--- a/src/hook/useSubcategory.jsx
+++ b/src/hook/useSubcategory.jsx
@@ -20,11 +20,11 @@ export const SubCategoryCreate = async (formData,) => {
 };
 
 // subcatagory ALL GET
-export const SubCategoryAllGet = async (dispatch, filterType) => {
+export const SubCategoryAllGet = async (dispatch, filterType, status) => {
   try {
     const url = filterType 
-      ? `/subcategories?filterType=${filterType}` 
-      : `/subcategories`;
+      ? `/subcategories?filterType=${filterType}&status=${status || "all"}` 
+      : `/subcategories?status=${status || "all"}`;
     const response = await apiClient.get(url, {
       withCredentials: true,
       headers: {

--- a/src/hook/usecategory.jsx
+++ b/src/hook/usecategory.jsx
@@ -18,9 +18,10 @@ export const CategoryCreate = async (formData,) => {
 };
 
 // catagory ALL GET
-export const CategoryAllGet = async (dispatch) => {
+export const CategoryAllGet = async (dispatch, status) => {
   try {
-    const response = await apiClient.get(`/categories`, {
+    const url = status ? `/categories?status=${status}` : `/categories`;
+    const response = await apiClient.get(url, {
       withCredentials: true,
     });
     if (dispatch) {

--- a/src/redux/cartSlice.js
+++ b/src/redux/cartSlice.js
@@ -1,37 +1,28 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-// Helper to get initial state from localStorage safely
-const getStoredCoupon = () => {
-    if (typeof window === "undefined") return null;
-    try {
-        const stored = localStorage.getItem("appliedCoupon");
-        return stored ? JSON.parse(stored) : null;
-    } catch (e) {
-        return null;
-    }
-};
-
-const getStoredDiscount = () => {
-    if (typeof window === "undefined") return 0;
-    try {
-        const stored = localStorage.getItem("couponDiscount");
-        return stored ? Number(stored) : 0;
-    } catch (e) {
-        return 0;
-    }
-};
-
 const cartSlice = createSlice({
     name: "cart",
     initialState: {
         items: [],
-        appliedCoupon: getStoredCoupon(),
-        couponDiscount: getStoredDiscount(),
+        appliedCoupon: null,
+        couponDiscount: 0,
         loading: false,
         error: null,
     },
 
     reducers: {
+        hydrateCoupon: (state) => {
+            if (typeof window === "undefined") return;
+            try {
+                const stored = localStorage.getItem("appliedCoupon");
+                const discount = localStorage.getItem("couponDiscount");
+                state.appliedCoupon = stored ? JSON.parse(stored) : null;
+                state.couponDiscount = discount ? Number(discount) : 0;
+            } catch (e) {
+                state.appliedCoupon = null;
+                state.couponDiscount = 0;
+            }
+        },
         setCoupon: (state, action) => {
             state.appliedCoupon = action.payload.coupon;
             state.couponDiscount = action.payload.discountAmount;
@@ -131,6 +122,7 @@ export const {
     removeItemLocal,
     setCoupon,
     clearCoupon,
+    hydrateCoupon,
 } = cartSlice.actions;
 
 export default cartSlice.reducer;

--- a/src/utlis/useHomeBanner.jsx
+++ b/src/utlis/useHomeBanner.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useCallback } from "react";
 import { HomeBannerAllGet } from "../hook/useHomeBanner";
 
 // ✅ Custom hook
-export const useGetHomeBanner = () => {
+export const useGetHomeBanner = (sliderFor) => {
   const [homebanner, setHomeBanner] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -11,7 +11,7 @@ export const useGetHomeBanner = () => {
   const fetchHomebanner = useCallback(async () => {
     try {
       setLoading(true);
-      const data = await HomeBannerAllGet();
+      const data = await HomeBannerAllGet(sliderFor);
       setHomeBanner(data.data);
       setError(null);
     } catch (err) {
@@ -19,7 +19,7 @@ export const useGetHomeBanner = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [sliderFor]);
 
   useEffect(() => {
     fetchHomebanner();


### PR DESCRIPTION
… crashes

- Add status param to CategoryAllGet/SubCategoryAllGet hooks for admin dashboard
- Pass status=all from admin callers (addCategories, subCategory, manageCoupons)
- Add sliderFor param to HomeBanner hook for USER/DROPSHIPPING filtering
- Add tab toggle in dashboard home slider for USER vs DROPSHIPPING banners
- Fix cartSlice hydration mismatch (hydrateCoupon reducer)
- Fix socket.jsx SSR crash + WebSocket 308 (browser-only guard + polling fallback)
- Fix order?.products.length crashes in pending/shipped/completed orders + orderList
- Fix cartItems.length crash in header + section.products.length in DropshippingSearch
- Add revalidate API route